### PR TITLE
fix(ci): disable pester-tests workflow until virtual environment setup

### DIFF
--- a/.github/workflows/pester-tests.yml
+++ b/.github/workflows/pester-tests.yml
@@ -1,8 +1,14 @@
 name: Run Pester Tests
 
-# Note: This workflow is not part of the main CI pipeline defined in CI.yaml.
-# It is intended for running Pester tests independently.
+# Note: This workflow is DISABLED until virtual environment setup is completed.
+# It is intended for running Pester tests independently once environment is ready.
 
+# DISABLED - Using workflow_dispatch only (manual trigger)
+# Remove the workflow_dispatch and uncomment the push/pull_request triggers when ready
+on:
+  workflow_dispatch:  # Manual trigger only - workflow is effectively disabled
+
+# FUTURE TRIGGERS (uncomment when ready):
 # on:
 #   push:
 #     branches:


### PR DESCRIPTION
##  **Fix: Disable Pester Tests Workflow**

**Problem:** 
- pester-tests.yml workflow had commented out triggers causing GitHub Actions error
- Error: 'No event triggers defined in on' 

**Solution:**
- Changed to workflow_dispatch only (manual trigger)
- Effectively disables automatic execution until virtual environment is ready
- Prevents workflow validation errors in GitHub Actions

**Impact:**
-  Resolves GitHub Actions workflow configuration error
-  Pester tests will not run automatically until re-enabled
-  Can still be triggered manually if needed
-  Ready for future virtual environment setup

**Next Steps:**
- Setup virtual environment for Pester tests (future task)
- Re-enable automatic triggers when environment is ready