### PR TITLE
fix: critical CI/CD pipeline version override and permissions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,7 +44,9 @@ jobs:
     runs-on: windows-latest
     environment: production
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-
+    permissions:
+      contents: write  # Required for creating releases and pushing tags
+      
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -93,12 +95,15 @@ jobs:
           $commitCount = ($commits | Measure-Object).Count
         }
 
-        # Check for manual version override in commit message
-        $latestCommit = git log -1 --pretty=format:"%s"
+        # Check for manual version override in ANY commit since last tag
         $manualVersion = $null
-        if ($latestCommit -match 'version:\s*v?(\d+\.\d+\.\d+)') {
-          $manualVersion = $matches[1]
-          Write-Host "Manual version override detected: v$manualVersion"
+        foreach ($commit in $commits) {
+          if ($commit -match 'version:\s*v?(\d+\.\d+\.\d+)') {
+            $manualVersion = $matches[1]
+            Write-Host "Manual version override detected in commit: $commit"
+            Write-Host "Override version: v$manualVersion"
+            break
+          }
         }
 
         # If manual version specified, use it


### PR DESCRIPTION
##  Critical Bug Fixes for Release Pipeline

This PR resolves two critical issues preventing v1.1.0 release:

###  Issues Fixed:
1. **Version Override Detection Bug**: Fixed logic to check ALL commits since last tag, not just merge commits
2. **GitHub Actions Permissions**: Added contents: write permission for tag creation and release publishing

###  Root Causes:
- Merge commit messages don't contain original commit messages with version overrides
- GitHub Actions bot lacks permission to push tags without explicit contents: write

###  Expected Results:
- Manual version override ersion: 1.1.0 will be properly detected
- GitHub Actions can successfully create tags and releases
- Release pipeline will create v1.1.0 instead of unwanted v2.0.0

###  Changed Files:
- .github/workflows/CI.yml: Enhanced version override detection + added permissions

Ready for immediate merge to fix broken release pipeline.